### PR TITLE
Исправлена бага подгрузки настроек в реальном времени

### DIFF
--- a/Alchemistry/Assets/Scripts/Managers/SettingsManager.cs
+++ b/Alchemistry/Assets/Scripts/Managers/SettingsManager.cs
@@ -30,11 +30,13 @@ public class SettingsManager : ISettingsManager
 	public void ChangeSetting(string key, int value)
 	{
 		PlayerPrefs.SetInt(key, value);
+		LoadSettings();
 	}
 
 	public void ChangeSetting(string key, string value)
 	{
 		PlayerPrefs.SetString(key, value);
+		LoadSettings();
 	}
 }
 


### PR DESCRIPTION
При изменении настроек, они записывались в реестр, но в коде ничего не менялось и только при следующем запуске настройки считывались из реестра. Добавил проход по всем настройкам после каждого изменении настроек